### PR TITLE
TextChannel.send() method now expects a string, or MessageOptions type.

### DIFF
--- a/src/client/rest/RestAPIHandler.ts
+++ b/src/client/rest/RestAPIHandler.ts
@@ -50,16 +50,11 @@ export default class RestAPIHandler {
   }
 
   async createMessage(options: MessageOptions, id: string) {
-    const data = {
-      "content": options.content,
-      "tts": options.tts,
-    };
     const response = await fetch(`${Constants.API}/${ENDPOINTS.CHANNELS}/${id}/${ENDPOINTS.MESSAGES}`, {
       method: 'POST',
       headers,
-      body: JSON.stringify(data),
+      body: JSON.stringify(options),
     });
-    console.log(response);
     return response.json();
   }
   

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,12 @@ import { Client } from '../mod.ts';
 import "https://deno.land/x/dotenv/load.ts";
 import Guild from './models/Guild.ts';
 import Message from './models/Message.ts';
-import { TextChannel } from './models/channels/TextChannel.ts';
 
 const client = new Client();
 client.login(Deno.env.get('BOT_TOKEN')!.toString());
 
 client.on('ready', () => {
   console.log('Bot has logged in.');
-  const guild: Guild = client.guilds.get('533070839806165023');
-  const members = guild.members;
 });
 
 client.on('guildCreate', (guild: Guild) => {
@@ -19,15 +16,17 @@ client.on('guildCreate', (guild: Guild) => {
 
 client.on('message', (message: Message) => {
   if (message.content === '?hello') {
+    message.channel.send('hello');
+  } else if (message.content === '?embed') {
     message.channel.send({
-      content: 'Hello!',
-      tts: false,
-    });
-  } else if (message.content === '?help') {
-    message.channel.send({
-      content: 'help command'
+      content: 'Hello',
+      embed: {
+        title: 'Hi',
+        description: 'Yoooo'
+      }
     })
   }
+
 });
 
 client.on('debug', (data: any) => {

--- a/src/models/channels/TextChannel.ts
+++ b/src/models/channels/TextChannel.ts
@@ -27,8 +27,16 @@ export class TextChannel extends GuildChannel implements TextBasedChannel {
     super(_id, _client, _type, _lastMessageId, _lastPinTimestamp, _name, _position, _parentId, _topic, _guild, _permissionOverwrites, _nsfw, _rateLimitPerUser);
   }
 
-  send(options: MessageOptions): any {
-    const response = this.client.rest.createMessage(options, this.id);
-    console.log(response);
+  send(payload: string | MessageOptions): any {
+    if (typeof payload === 'string') {
+      const body: MessageOptions = { content: payload };
+      const response = this.client.rest.createMessage(body, this.id);
+      return;
+    }
+    
+    if (payload && payload.content) {
+      const response = this.client.rest.createMessage(payload, this.id);
+      return;
+    }
   }
 }

--- a/src/models/interfaces/ITextChannel.ts
+++ b/src/models/interfaces/ITextChannel.ts
@@ -3,5 +3,5 @@ import { MessageOptions } from '../../typedefs/MessageOptions.ts';
 
 export default interface TextBasedChannel {
 
-  send(options: MessageOptions): any;
+  send(payload: string | MessageOptions): any;
 }

--- a/src/typedefs/MessageOptions.ts
+++ b/src/typedefs/MessageOptions.ts
@@ -1,5 +1,10 @@
 export interface MessageOptions {
-  content: string;
+  content?: string;
   tts?: boolean;
-  embed?: any;
+  embed?: MessageEmbed;
+}
+
+export interface MessageEmbed {
+  title: string;
+  description?: string
 }


### PR DESCRIPTION
TextChannel.send() previously expected only a MessageOptions type, now it supports either String or MessageOptions.